### PR TITLE
小数点切り上げが機能しないバグを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,7 @@
         }
         function decimalPointCalculate(value, decimalPoint){
             if(decimalPoint === 'ceil'){
-                // return value.ceil()
-                return value.floor()
+                return value.ceil()
             }
             if(decimalPoint === 'floor'){
                 return value.floor()


### PR DESCRIPTION
## 変更後の振る舞い
小数点以下切り上げが正しく機能する

## 変更前の振る舞い
小数点以下切り上げが切り下げになっていた